### PR TITLE
修复ip获取错误的bug

### DIFF
--- a/raincat-common/src/main/java/com/raincat/common/holder/NetUtils.java
+++ b/raincat-common/src/main/java/com/raincat/common/holder/NetUtils.java
@@ -1,0 +1,175 @@
+package com.raincat.common.holder;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.*;
+import java.util.Enumeration;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+
+/**
+ *
+ * 网络工具类
+ *
+ * @author fishermen
+ * @version V1.0 created at: 2013-5-28
+ */
+public class NetUtils {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(NetUtils.class);
+
+    public static final String LOCALHOST = "127.0.0.1";
+
+    public static final String ANYHOST = "0.0.0.0";
+
+    private static volatile InetAddress LOCAL_ADDRESS = null;
+
+    private static final Pattern LOCAL_IP_PATTERN = Pattern.compile("127(\\.\\d{1,3}){3}$");
+
+    private static final Pattern ADDRESS_PATTERN = Pattern.compile("^\\d{1,3}(\\.\\d{1,3}){3}\\:\\d{1,5}$");
+
+    private static final Pattern IP_PATTERN = Pattern.compile("\\d{1,3}(\\.\\d{1,3}){3,5}$");
+
+    public static boolean isInvalidLocalHost(String host) {
+        return host == null || host.length() == 0 || host.equalsIgnoreCase("localhost") || host.equals("0.0.0.0")
+                || (LOCAL_IP_PATTERN.matcher(host).matches());
+    }
+
+    public static boolean isValidLocalHost(String host) {
+        return !isInvalidLocalHost(host);
+    }
+
+    /**
+     *
+     */
+    public static InetAddress getLocalAddress() {
+        return getLocalAddress(null);
+    }
+
+    /**
+     * <pre>
+     * 查找策略：首先看是否已经查到ip --> hostname对应的ip --> 根据连接目标端口得到的本地ip --> 轮询网卡
+     * </pre>
+     *
+     */
+    public static InetAddress getLocalAddress(Map<String, Integer> destHostPorts) {
+        if (LOCAL_ADDRESS != null) {
+            return LOCAL_ADDRESS;
+        }
+
+        InetAddress localAddress = getLocalAddressByHostname();
+        if (!isValidAddress(localAddress)) {
+            localAddress = getLocalAddressBySocket(destHostPorts);
+        }
+
+        if (!isValidAddress(localAddress)) {
+            localAddress = getLocalAddressByNetworkInterface();
+        }
+
+        if (isValidAddress(localAddress)) {
+            LOCAL_ADDRESS = localAddress;
+        }
+
+        return localAddress;
+    }
+
+    private static InetAddress getLocalAddressByHostname() {
+        try {
+            InetAddress localAddress = InetAddress.getLocalHost();
+            if (isValidAddress(localAddress)) {
+                return localAddress;
+            }
+        } catch (Throwable e) {
+            LogUtil.warn(LOGGER,"Failed to retriving local address by hostname:{}" ,()-> e);
+        }
+        return null;
+    }
+
+    private static InetAddress getLocalAddressBySocket(Map<String, Integer> destHostPorts) {
+        if (destHostPorts == null || destHostPorts.size() == 0) {
+            return null;
+        }
+
+        for (Map.Entry<String, Integer> entry : destHostPorts.entrySet()) {
+            String host = entry.getKey();
+            int port = entry.getValue();
+            try {
+                Socket socket = new Socket();
+                try {
+                    SocketAddress addr = new InetSocketAddress(host, port);
+                    socket.connect(addr, 1000);
+                    return socket.getLocalAddress();
+                } finally {
+                    try {
+                        socket.close();
+                    } catch (Throwable e) {}
+                }
+            } catch (Exception e) {
+                LogUtil.warn(LOGGER,"Failed to retriving local address by connecting to dest host:port:{}" ,()-> host+":"+port+",exception:"+e);
+            }
+        }
+        return null;
+    }
+
+    private static InetAddress getLocalAddressByNetworkInterface() {
+        try {
+            Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+            if (interfaces != null) {
+                while (interfaces.hasMoreElements()) {
+                    try {
+                        NetworkInterface network = interfaces.nextElement();
+                        Enumeration<InetAddress> addresses = network.getInetAddresses();
+                        while (addresses.hasMoreElements()) {
+                            try {
+                                InetAddress address = addresses.nextElement();
+                                if (isValidAddress(address)) {
+                                    return address;
+                                }
+                            } catch (Throwable e) {
+                                LogUtil.warn(LOGGER,"Failed to retriving ip address,{}" ,()->e);
+                            }
+                        }
+                    } catch (Throwable e) {
+                        LogUtil.warn(LOGGER,"Failed to retriving ip address,{}" ,()->e);
+                    }
+                }
+            }
+        } catch (Throwable e) {
+            LogUtil.warn(LOGGER,"Failed to retriving ip address,{}" ,()->e);
+        }
+        return null;
+    }
+
+    public static boolean isValidAddress(String address) {
+        return ADDRESS_PATTERN.matcher(address).matches();
+    }
+
+    public static boolean isValidAddress(InetAddress address) {
+        if (address == null || address.isLoopbackAddress()) return false;
+        String name = address.getHostAddress();
+        return (name != null && !ANYHOST.equals(name) && !LOCALHOST.equals(name) && IP_PATTERN.matcher(name).matches());
+    }
+    //return ip to avoid lookup dns
+    public static String getHostName(SocketAddress socketAddress) {
+        if (socketAddress == null) {
+            return null;
+        }
+
+        if (socketAddress instanceof InetSocketAddress) {
+            InetAddress addr = ((InetSocketAddress) socketAddress).getAddress();
+            if(addr != null){
+                return addr.getHostAddress();
+            }
+        }
+
+        return null;
+    }
+
+    public static void main(String[] args) {
+        System.out.println(NetUtils.getLocalAddress().getHostAddress());
+        System.out.println(NetUtils.getLocalAddressByHostname());
+        System.out.println(NetUtils.getLocalAddressByNetworkInterface());
+    }
+}

--- a/raincat-manager/src/main/java/com/raincat/manager/spring/ApplicationStartListener.java
+++ b/raincat-manager/src/main/java/com/raincat/manager/spring/ApplicationStartListener.java
@@ -18,13 +18,14 @@
 
 package com.raincat.manager.spring;
 
+import com.raincat.common.holder.LogUtil;
+import com.raincat.common.holder.NetUtils;
 import com.raincat.manager.config.Address;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.embedded.EmbeddedServletContainerInitializedEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.stereotype.Component;
-
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 
 
 /**
@@ -33,7 +34,7 @@ import java.net.UnknownHostException;
  */
 @Component
 public class ApplicationStartListener implements ApplicationListener<EmbeddedServletContainerInitializedEvent> {
-
+    private static final Logger LOGGER = LoggerFactory.getLogger(ApplicationStartListener.class);
     @Override
     public void onApplicationEvent(final EmbeddedServletContainerInitializedEvent event) {
         int port = event.getEmbeddedServletContainer().getPort();
@@ -42,14 +43,10 @@ public class ApplicationStartListener implements ApplicationListener<EmbeddedSer
                 .setHost(host)
                 .setPort(port)
                 .setDomain(String.join(":", host, String.valueOf(port)));
+        LogUtil.info(LOGGER,"bind host:port，{}",()->host+":"+port);
     }
 
     private String getHost() {
-        try {
-            return InetAddress.getLocalHost().getHostAddress();
-        } catch (UnknownHostException e) {
-            e.printStackTrace();
-            return "127.0.0.1";
-        }
+        return NetUtils.getLocalAddress().getHostAddress();
     }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9690089/45014876-892c7880-b052-11e8-8a68-dd643e9f99de.png)

此处获取ip有可能获取错误，获取的ip为127.0.0.1时，有误。
假设txManager集群，且参与者两个集群都有连接到，最终通知所有人提交或者回滚的时候。
如果ip都为127.0.0.1时，无法区分其他参与者链接的txManager。会有可能通知失败。